### PR TITLE
Update graphql dependency in gql-format and gql-merge

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 .*/packages/.*/lib
 .*/packages/.*/test
+.*/packages/.*/node_modules
 
 [include]
 packages/*/src

--- a/packages/gql-format/package.json
+++ b/packages/gql-format/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/liamcurry/gql/tree/master/packages/gql-format#readme",
   "dependencies": {
     "commander": "^2.9.0",
-    "graphql": "0.9.2"
+    "graphql": "^0.11.0"
   },
   "devDependencies": {
     "ava": "^0.19.0"

--- a/packages/gql-merge/package.json
+++ b/packages/gql-merge/package.json
@@ -20,7 +20,7 @@
     "commander": "^2.9.0",
     "gql-format": "^0.0.5",
     "gql-utils": "^0.0.2",
-    "graphql": "0.9.2"
+    "graphql": "^0.11.0"
   },
   "devDependencies": {
     "ava": "^0.19.0"


### PR DESCRIPTION
The specified graphql version in gql-merge and gql-format currently prevents me from upgrading my `graphql` version, as multiple versions of `graphql` in node_modules has some [issues due to `instanceof` checks](https://github.com/graphql/graphql-js/issues/491).

I checked the [changelog of `graphql`](https://github.com/graphql/graphql-js/releases) and it looks like this library shouldn't be affected by breaking changes there.

I tried running your tests, but after `lerna bootstrap` I got an error: `Error: Cannot find module 'gql-utils'`. I'm not sure where that issue originates from.

Also flow finds some errors both in the `graphql` package as well as in your lib code. I added `node_modules` to your ignored flow files to get rid of the former ones, but I'm not sure where the others are coming from.

Also the lint task returns a bunch of errors – I don't think they are related to the upgrade of graphql, are they?

---

Another option would be to remove `graphql` from `dependencies` and move them to `peerDependencies`. WDYT?