### PR TITLE
Added support for multiline comments.

### DIFF
--- a/packages/gql-format/src/index.js
+++ b/packages/gql-format/src/index.js
@@ -232,7 +232,7 @@ Object
 function withDescription(fn) {
     return function (node) {
         const desc = getDescription(node);
-        const descText = desc ? '# ' + desc + '\n' : '';
+        const descText = desc ? desc.replace(/^/gm, '# ') + '\n' : '';
         return descText + fn(node);
     }
 }

--- a/packages/gql-format/test/index.js
+++ b/packages/gql-format/test/index.js
@@ -12,7 +12,8 @@ test('formatString', async t => {
 # Foo is a thing
 type Foo {
 
-  # Baz is a string
+  # Baz is a string, and it
+  # is optional.
   baz: String
 
 }`
@@ -24,7 +25,8 @@ type Foo {
 
 # Foo is a thing
 type Foo {
-  # Baz is a string
+  # Baz is a string, and it
+  # is optional.
   baz: String
 }
 `;


### PR DESCRIPTION
Previously, the mode for collecting comment was done in a way that would not support multi-line comments as the graphql parser does. This resolves that by replacing the comment/description formatting with a regex replacement.